### PR TITLE
fix python version to 2.7 to accord with the use of sets within curly brace synatx

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 Required packages
 -----------------
 
-To run the PyPI software, you need Python 2.5+ and PostgreSQL
+To run the PyPI software, you need Python 2.7+ and PostgreSQL
 
 
 Quick development setup


### PR DESCRIPTION
Current instructions do not accurately portray the python 2.7 requirement that was introduced in commit 
5dea00b6 by including sets defined by `{}` delimiters.