### PR TITLE
Implement pep 503 for simple repository.

### DIFF
--- a/store.py
+++ b/store.py
@@ -718,15 +718,18 @@ class Store:
         file_urls = []
 
         # uploaded files
-        safe_execute(cursor, '''select filename, python_version, md5_digest
-            from release_files where name=%s''', (name,))
-        for fname, pyversion, md5 in cursor.fetchall():
+        safe_execute(cursor,
+        '''
+        SELECT filename, requires_python, md5_digest
+        FROM release_files
+        WHERE release_files.name=%s
+        ''', (name,))
+        for fname, requires_python, md5 in cursor.fetchall():
             # Put files first, to have setuptools consider
             # them before going to other sites
-            url = self.gen_file_url(pyversion, name, fname, relative) + \
+            url = self.gen_file_url('<not used arg>', name, fname, relative) + \
                 "#md5=" + md5
-            file_urls.append((url, "internal", fname))
-
+            file_urls.append((url, "internal", fname, requires_python))
         return sorted(file_urls)
 
     def get_uploaded_file_urls(self, name):

--- a/webui.py
+++ b/webui.py
@@ -1042,7 +1042,7 @@ class WebUI:
         html.append("""<html><head><title>Links for %s</title><meta name="api-version" value="2" /></head>"""
                     % cgi.escape(path))
         html.append("<body><h1>Links for %s</h1>" % cgi.escape(path))
-        for href, rel, text in urls:
+        for href, rel, text, requires_python in urls:
             if href.startswith('http://cheeseshop.python.org/pypi') or \
                     href.startswith('http://pypi.python.org/pypi') or \
                     href.startswith('http://www.python.org/pypi'):
@@ -1054,7 +1054,10 @@ class WebUI:
                 rel = ''
             href = cgi.escape(href, quote=True)
             text = cgi.escape(text)
-            html.append("""<a href="%s"%s>%s</a><br/>\n""" % (href, rel, text))
+            data_attr = ''
+            if requires_python:
+                data_attr = ' data-requires-python="{}"'.format(cgi.escape(requires_python))
+            html.append('<a%s href="%s"%s>%s</a><br/>\n' % (data_attr, href, rel, text))
         html.append("</body></html>")
         html = ''.join(html)
         return html

--- a/webui.py
+++ b/webui.py
@@ -345,12 +345,16 @@ def _simple_body_internal(path, urls):
                 href.startswith('http://www.python.org/pypi'):
             # Suppress URLs that point to us
             continue
+        if rel:
+            rel = ' rel="{}"'.format(cgi.escape(rel))
+        else:
+            rel = ''
         href = cgi.escape(href, quote=True)
         text = cgi.escape(text)
         data_attr = ''
         if requires_python:
             data_attr = ' data-requires-python="{}"'.format(cgi.escape(requires_python, quote=True)) 
-        html.append("""<a%s href="%s">%s</a><br/>\n""" % (data_attr, href, text))
+        html.append("""<a{} href="{}"{}>{}</a><br/>\n""".format(data_attr, href, rel, text))
     html.append("</body></html>")
     html = ''.join(html)
     return html

--- a/webui.py
+++ b/webui.py
@@ -346,7 +346,7 @@ def _simple_body_internal(path, urls):
             # Suppress URLs that point to us
             continue
         if rel:
-            rel = ' rel="{}"'.format(cgi.escape(rel))
+            rel = ' rel="{}"'.format(cgi.escape(rel, quote=True))
         else:
             rel = ''
         href = cgi.escape(href, quote=True)


### PR DESCRIPTION
Implement pep 503 data-requires for simple repository.

This exposes the data-requires-python field when the packages registers it.

This also expand the readme with some basic instruction on how to connect
pypi-legacy to a running warehouse setup.

SQL seem to be ~2x to 5x slower, but likely still reasonable time

SQL Before :

```
    explain analyse select filename, python_version, md5_digest from release_files where name='ipython_sql'

    Index Scan using release_files_name_idx on release_files  (cost=0.29..15.60 rows=3 width=66) (actual time=0.028..0.028 rows=0 loops=1)
      Index Cond: (name = 'ipython_sql'::text)
    Planning time: 0.224 ms
    Execution time: 0.058 ms
```

SQL After :

```
    explain analyse select filename, releases.requires_python, md5_digest
    from release_files
    inner join releases
        on release_files.version=releases.version
        and release_files.name=releases.name
    where release_files.name='ipython_sql'

    Nested Loop  (cost=4.60..31.74 rows=1 width=61) (actual time=0.013..0.013 rows=0 loops=1)
      Join Filter: (release_files.version = releases.version)
      ->  Index Scan using release_files_name_idx on release_files  (cost=0.29..15.60 rows=3 width=77) (actual time=0.012..0.012 rows=0 loops=1)
            Index Cond: (name = 'ipython_sql'::text)
      ->  Materialize  (cost=4.31..16.01 rows=3 width=18) (never executed)
            ->  Bitmap Heap Scan on releases  (cost=4.31..16.00 rows=3 width=18) (never executed)
                  Recheck Cond: (name = 'ipython_sql'::text)
                  ->  Bitmap Index Scan on release_name_idx  (cost=0.00..4.31 rows=3 width=0) (never executed)
                        Index Cond: (name = 'ipython_sql'::text)
    Planning time: 0.668 ms
    Execution time: 0.092 ms
```

Likely longer for project with more releases.
