### PR TITLE
add ability to destroy existing documentation on pythonhosted.org for…

### DIFF
--- a/store.py
+++ b/store.py
@@ -2156,16 +2156,21 @@ class Store:
         if not row[0]:
             raise LockedException
 
-    def set_has_docs(self, name):
+    def set_has_docs(self, name, value=True):
         cursor = self.get_cursor()
-        sql = "UPDATE packages SET has_docs = 't' WHERE name = %s"
+        if value:
+            sql = "UPDATE packages SET has_docs = 't' WHERE name = %s"
+        else:
+            sql = "UPDATE packages SET has_docs = 'f' WHERE name = %s"
         safe_execute(cursor, sql, (name,))
 
-    def log_docs(self, name, version):
+    def log_docs(self, name, version, operation=None):
+        if operation is None:
+            operation = 'docupdate'
         cursor = self.get_cursor()
         date = time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime())
-        self.add_journal_entry(name, version, "docupdate", date,
-                                                self.username, self.userip)
+        self.add_journal_entry(name, version, operation, date,
+                               self.username, self.userip)
 
     def docs_url(self, name):
         '''Determine the local (pythonhosted.org) documentation URL, if any.

--- a/templates/pkg_edit.pt
+++ b/templates/pkg_edit.pt
@@ -99,7 +99,7 @@ Only static pages are supported. The zip file must have a top-level
 <p>If you would like to <b>DESTROY</b> any existing documentation hosted at
 <a tal:attributes="href string:http://pythonhosted.org/${data/name}"
 tal:content="string:http://pythonhosted.org/${data/name}"></a>
-Use this button. There is <b>no undo</b>.
+Use this button, There is <b>no undo</b>.
 </p>
 <form tal:attributes="action app/url_path" method="POST"
     enctype="multipart/form-data">

--- a/templates/pkg_edit.pt
+++ b/templates/pkg_edit.pt
@@ -96,6 +96,18 @@ Only static pages are supported. The zip file must have a top-level
 <input type="submit" value="Upload Documentation" />
 </form>
 
+<p>If you would like to <b>DESTROY</b> any existing documentation hosted at
+<a tal:attributes="href string:http://pythonhosted.org/${data/name}"
+tal:content="string:http://pythonhosted.org/${data/name}"></a>
+Use this button. There is <b>no undo</b>.
+</p>
+<form tal:attributes="action app/url_path" method="POST"
+    enctype="multipart/form-data">
+<input type="hidden" name=":action" value="doc_destroy" />
+<input type="hidden" name="name" tal:attributes="value data/name" />
+<input type="submit" value="Destroy Documentation" />
+</form>
+
 <p></p>
 
 <div class="delete-project">

--- a/webui.py
+++ b/webui.py
@@ -862,7 +862,7 @@ class WebUI:
         forgotten_password_form forgotten_password
         password_reset pw_reset pw_reset_change
         role role_form list_classifiers login logout files
-        file_upload show_md5 doc_upload claim openid openid_return dropid
+        file_upload show_md5 doc_upload doc_destroy claim openid openid_return dropid
         clear_auth addkey delkey lasthour json gae_file about delete_user
         rss_regen openid_endpoint openid_decide_post packages_rss
         exception login_form purge'''.split():

--- a/webui.py
+++ b/webui.py
@@ -3124,7 +3124,7 @@ class WebUI:
         try:
             self.store.lock_docs(name)
         except store.LockedException:
-            raise FormError, "Error: Another doc upload is in progress."
+            raise FormError, "Error: Another doc modification is in progress."
 
         # Assume the file is valid; remove any previous data
         if self.docs_fs.exists(name):
@@ -3150,10 +3150,55 @@ class WebUI:
         except Exception, e:
             raise FormError, "Error unpacking zipfile:" + str(e)
 
-        self.store.set_has_docs(name)
-        self.store.log_docs(name, version)
+        self.store.set_has_docs(name, value=True)
+        self.store.log_docs(name, version, 'docupdate')
         self.store.changed()
         raise Redirect("https://pythonhosted.org/%s/" % name)
+
+    #
+    # Documentation Destruction
+    #
+    @must_tls
+    def doc_destroy(self):
+        # make sure the user is identified
+        if not self.authenticated:
+            raise Unauthorised, \
+                "You must be identified to edit package information"
+
+        # only allow via WebUI
+        self.csrf_check()
+
+        # figure the package name and version
+        name = version = None
+        if self.form.has_key('name'):
+            name = self.form['name']
+        if not name:
+            raise FormError, 'No package name given'
+
+        # make sure the user has permission to do stuff
+        if not (self.store.has_role('Owner', name) or
+                self.store.has_role('Admin', name) or
+                self.store.has_role('Maintainer', name)):
+            raise Forbidden, \
+                "You are not allowed to edit '%s' package information"%name
+
+        try:
+            self.store.lock_docs(name)
+        except store.LockedException:
+            raise FormError, "Error: Another doc modification is in progress."
+
+        # Assume the file is valid; remove any previous data
+        if self.docs_fs.exists(name):
+            for dirname, files in self.docs_fs.walk(name, search="depth"):
+                for filename in files:
+                    self.docs_fs.remove(os.path.join(dirname, filename))
+                self.docs_fs.removedir(dirname)
+
+        self.store.set_has_docs(name, value=False)
+        self.store.log_docs(name, version, 'docdestroy')
+        self.store.changed()
+        self.write_template('message.pt', title='Documentation Destroyed',
+                            message='Documentation Destroyed for %s.' % (name,),)
 
     #
     # Reverse download for Google AppEngine


### PR DESCRIPTION
Addresses the ability to destroy documentation hosted on pythonhosted.org, unsets `has_docs`.

This addresses #24, including the most recent comment here https://github.com/pypa/pypi-legacy/issues/24#issuecomment-244607218
