### PR TITLE
Fixed classifiers handling

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -2351,18 +2351,11 @@ class WebUI:
         # make sure relationships are lists
         for name in ('requires', 'provides', 'obsoletes',
                      'requires_dist', 'provides_dist',
-                     'obsoletes_dist',
+                     'obsoletes_dist', 'classifier'
                      'requires_external', 'project_url'):
             if data.has_key(name) and not isinstance(data[name],
                     types.ListType):
                 data[name] = [data[name]]
-
-        # rename classifiers
-        if data.has_key('classifier'):
-            classifiers = data['classifier']
-            if not isinstance(classifiers, types.ListType):
-                classifiers = [classifiers]
-            data['classifiers'] = classifiers
 
         # Trim docstrings
         if "description" in data:


### PR DESCRIPTION
Note: untested, but should fix sentry issue #147474868

The metadata will not validate with `classifiers` as key, it has to be `classifier`