### PR TITLE
clarify error message when submitting bad PKG-INFO

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -135,6 +135,8 @@ class OpenIDError(Exception):
     pass
 class OAuthError(Exception):
     pass
+class PkgInfoError(Exception):
+    pass
 class BlockedIP(Exception):
     pass
 class MultipleReleases(Exception):
@@ -531,6 +533,9 @@ class WebUI:
             except FormError, message:
                 message = str(message)
                 self.fail(message, code=400, heading='Error processing form')
+            except PkgInfoError, message:
+                message = str(message)
+                self.fail(message, code=400, heading='Error processing PKG-INFO data')
             except OpenIDError, message:
                 message = str(message)
                 self.fail(message, code=400, heading='Error processing OpenID request')
@@ -2323,7 +2328,7 @@ class WebUI:
             try:
                 pkginfo = pkginfo.decode('utf8')
             except UnicodeDecodeError:
-                raise FormError, \
+                raise PkgInfoError, \
                     "Your PKG-INFO file must be either ASCII or UTF-8. " \
                     "If this is inconvenient, use 'python setup.py register'."
         mess = email.message_from_file(cStringIO.StringIO(pkginfo))
@@ -2372,7 +2377,7 @@ class WebUI:
         try:
             self.validate_metadata(data)
         except ValueError, message:
-            raise FormError, message
+            raise PkgInfoError, message
 
         name = data['name']
         version = data['version']


### PR DESCRIPTION
#545 showed that using a `FormError` can be a bit confusing as the only form data accepted for this method is a `PKG-INFO` file.