### PR TITLE
confirm deleting release files

### DIFF
--- a/templates/files.pt
+++ b/templates/files.pt
@@ -131,7 +131,7 @@ href="https://packaging.python.org/en/latest/distributing.html#uploading-your-pr
 
  <tr tal:condition="data/maintainer">
   <td colspan="7" id="last">
-   <input type="submit" name="submit_remove" value="Remove" />
+   <input type="submit" name="submit_remove" value="Remove" onclick="return confirm('You can never use this filename again, are you sure?')"/>
   </td>
  </tr>
 

--- a/templates/files.pt
+++ b/templates/files.pt
@@ -131,7 +131,7 @@ href="https://packaging.python.org/en/latest/distributing.html#uploading-your-pr
 
  <tr tal:condition="data/maintainer">
   <td colspan="7" id="last">
-   <input type="submit" name="submit_remove" value="Remove" onclick="return confirm('You can never use this filename again, are you sure?')"/>
+   <input type="submit" name="submit_remove" value="Remove" onclick="return confirm('You can never use this/these filename(s) again, are you sure?');"/>
   </td>
  </tr>
 


### PR DESCRIPTION
At the moment removed files cannot be uploaded again later.
This patch mitigates a UX hazard where a maintainer might expect they just re-upload the file later.
See https://github.com/pypa/packaging-problems/issues/74
