### PR TITLE
xmlrpc debug and defense tools

### DIFF
--- a/config.ini.template
+++ b/config.ini.template
@@ -124,6 +124,10 @@ blocked_timeout = 600  ; in seconds
 blocked_attempts_ip = 10
 blocked_attempts_user = 1000
 
+; XMLRPC Settings
+[xmlrpc]
+request_log_file = /tmp/rpclog
+
 ; Authomatic
 [authomatic]
 secure = true

--- a/config.ini.template
+++ b/config.ini.template
@@ -11,6 +11,7 @@ queue_redis_url = redis://localhost:6379/0
 count_redis_url = redis://localhost:6379/1
 cache_redis_url = redis://localhost:6379/2
 block_redis_url = redis://localhost:6379/3
+xmlrpc_redis_url = redis://localhost:6379/4
 
 ; ElasticSearch
 ; releases_index_url = http://127.0.0.1:9200
@@ -126,6 +127,8 @@ blocked_attempts_user = 1000
 
 ; XMLRPC Settings
 [xmlrpc]
+max_concurrent = 10
+enforce = false
 request_log_file = /tmp/rpclog
 
 ; Authomatic

--- a/config.py
+++ b/config.py
@@ -145,6 +145,11 @@ class Config:
         self.blocked_attempts_user = c.get("blocking", "blocked_attempts_user")
         self.blocked_attempts_ip = c.get("blocking", "blocked_attempts_ip")
 
+        if c.has_option("xmlrpc", "request_log_file"):
+            self.xmlrpc_request_log_file = c.get("xmlrpc", "request_log_file")
+        else:
+            self.xmlrpc_request_log_file = None
+
         # Get Authomatic Secret
         self.authomatic_secure = c.get("authomatic", "secure")
         self.authomatic_secret = c.get("authomatic", "secret")

--- a/config.py
+++ b/config.py
@@ -116,6 +116,11 @@ class Config:
         else:
             self.block_redis_url = None
 
+        if c.has_option('database', 'xmlrpc_redis_url'):
+            self.xmlrpc_redis_url = c.get('database', 'xmlrpc_redis_url')
+        else:
+            self.xmlrpc_redis_url = None
+
         self.sentry_dsn = c.get('sentry', 'dsn')
 
         self.passlib = CryptContext(
@@ -144,6 +149,16 @@ class Config:
         self.blocked_timeout = c.get("blocking", "blocked_timeout")
         self.blocked_attempts_user = c.get("blocking", "blocked_attempts_user")
         self.blocked_attempts_ip = c.get("blocking", "blocked_attempts_ip")
+
+        if c.has_option("xmlrpc", "max_concurrent"):
+            self.xmlrpc_concurrent_requests = c.getint("xmlrpc", "max_concurrent")
+        else:
+            self.xmlrpc_concurrent_requests = 9999
+
+        if c.has_option("xmlrpc", "enforce"):
+            self.xmlrpc_enforce = c.getboolean("xmlrpc", "enforce")
+        else:
+            self.xmlrpc_enforce = False
 
         if c.has_option("xmlrpc", "request_log_file"):
             self.xmlrpc_request_log_file = c.get("xmlrpc", "request_log_file")

--- a/rpc.py
+++ b/rpc.py
@@ -10,6 +10,7 @@ import json
 from cStringIO import StringIO
 from SimpleXMLRPCServer import SimpleXMLRPCDispatcher
 from collections import defaultdict
+from contextlib import contextmanager
 
 from perfmetrics import metric
 from perfmetrics import metricmethod
@@ -35,6 +36,11 @@ else:
 package_tag_lru = RedisLru(cache_redis, expires=86400, tag="pkg~%s", arg_index=1, slice_obj=slice(1, None))
 cache_by_pkg = package_tag_lru.decorator
 
+if conf.xmlrpc_redis_url is None:
+    xmlrpc_redis = None
+else:
+    xmlrpc_redis = redis.StrictRedis.from_url(conf.xmlrpc_redis_url)
+
 STATSD_URI = "statsd://127.0.0.1:8125?prefix=%s" % (conf.database_name)
 set_statsd_client(STATSD_URI)
 
@@ -54,6 +60,43 @@ def log_xmlrpc_request(remote_addr, data):
         except Exception:
             pass
 
+
+def log_xmlrpc_throttle(remote_addr, enforced):
+    if conf.xmlrpc_request_log_file:
+        try:
+            with open(conf.xmlrpc_request_log_file, 'a') as f:
+                record = json.dumps({
+                    'timestamp': datetime.datetime.utcnow().isoformat(),
+                    'remote_addr': remote_addr,
+                    'method': 'throttled',
+                    'throttle_enforced': enforced,
+                })
+                f.write(record + '\n')
+        except Exception:
+            pass
+
+
+@contextmanager
+def throttle_concurrent(remote_addr):
+    throttled = False
+    try:
+        if xmlrpc_redis:
+            pipeline = xmlrpc_redis.pipeline()
+            pipeline.incr(remote_addr)
+            pipeline.expire(remote_addr, 60)
+            current = pipeline.execute()[0]
+            if current >= conf.xmlrpc_concurrent_requests:
+                log_xmlrpc_throttle(remote_addr, conf.xmlrpc_enforce)
+                if conf.xmlrpc_enforce:
+                    throttled = True
+    except Exception:
+        pass
+    yield throttled
+    try:
+        if xmlrpc_redis:
+            xmlrpc_redis.decr(remote_addr)
+    except Exception:
+        pass
 
 class RequestHandler(SimpleXMLRPCDispatcher):
     """A request dispatcher for the PyPI XML-RPC API."""
@@ -105,10 +148,18 @@ class RequestHandler(SimpleXMLRPCDispatcher):
             )
         else:
             log_xmlrpc_request(webui_obj.remote_addr, data)
-            # errors here are handled by _marshaled_dispatch
-            response = self._marshaled_dispatch(data)
-            # remove non-printable ASCII control codes from the response
-            response = re.sub('([\x00-\x08]|[\x0b-\x0c]|[\x0e-\x1f])+', '', response)
+            with throttle_concurrent(webui_obj.remote_addr) as is_throttled:
+                if is_throttled:
+                    response = xmlrpclib.dumps(
+                        xmlrpclib.Fault(429, 'max concurrent requests exceeded'),
+                        encoding=self.encoding,
+                        allow_none=self.allow_none
+                    )
+                else:
+                    # errors here are handled by _marshaled_dispatch
+                    response = self._marshaled_dispatch(data)
+                    # remove non-printable ASCII control codes from the response
+                    response = re.sub('([\x00-\x08]|[\x0b-\x0c]|[\x0e-\x1f])+', '', response)
         webui_obj.handler.wfile.write(response)
 
     @metricmethod


### PR DESCRIPTION
Implements configurable log and rate limiting for the XMLRPC endpoint.

Logs are intended to get better information on usage patterns.

Rate limiting will give us the ability to handle excessively noisy clients without having the backend workers get tied up. Rate limiting can be deployed in "enforcing" mode to actually throttle IPs with more than the configured number of concurrent requests in progress. Initially, we'll deploy it without enforcing to get a better feel for what appropriate settings might be!