### PR TITLE
strip known non-"Metadata 1.X" keys before calling distutils2.Metadata.check()

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -2580,7 +2580,8 @@ class WebUI:
         # so we can use its check() method
         metadata = Metadata()
         for key, value in data.items():
-            metadata[key] = value
+            if key not in ('blake2_256_digest', 'comment', 'filetype', 'md5_digest', 'protcol_version', 'pyversion', 'sha256_digest'):
+                metadata[key] = value
         metadata['Metadata-Version'] = '1.2'
         missing, warnings = metadata.check()
 


### PR DESCRIPTION
Some keys are either added by distutils during the upload method (such as misspelled `protcol_version`) or by our own forms/processing.

The method by which `distutils2.metadata._best_version()` guesses the version, causes failure as unknown keys disqualify all versions.