### PR TITLE
Update 'python powered' logo displayed in footer

### DIFF
--- a/templates/standard_template.pt
+++ b/templates/standard_template.pt
@@ -214,7 +214,7 @@
                 <img src="https://img.shields.io/badge/ipv6-go!-green.svg" alt='ipv6 ready' title='ipv6 ready' border='0'/><br />
                 <img src="https://img.shields.io/badge/http2-go!-green.svg" alt='http2 ready' title='http2 ready' border='0'/><br />
                 </tal:x>
-                <img src="/static/images/PythonPoweredAnimSmall.gif" alt='darn right it is' title='Python Powered' border='0'/>
+                <img src="https://www.python.org/static/community_logos/python-powered-w-70x28.png" alt='darn right it is' title='Python Powered' border='0'/>
               </div>
               <div style="float: right" id="donations">
                 <a href="http://www.python.org/about/website">Website maintained by the Python community</a><br />


### PR DESCRIPTION
The new URL displays a more up-to-date logo design.

Perhaps it would be better to replace the logo in /static directory instead of changing the link? Let me know if you prefer such modification.

