### PR TITLE
remove GPG Key ID handling from PyPI

### DIFF
--- a/store.py
+++ b/store.py
@@ -1567,7 +1567,7 @@ class Store:
             such user.
         '''
         cursor = self.get_cursor()
-        sql = """SELECT username, password, email, key_id, last_login
+        sql = """SELECT username, password, email, last_login
                     FROM accounts_user u
                         LEFT OUTER JOIN accounts_email e ON (e.user_id = u.id)
                     WHERE username = %s
@@ -1583,7 +1583,7 @@ class Store:
             such user.
         '''
         cursor = self.get_cursor()
-        sql = """SELECT username, password, email, key_id, last_login
+        sql = """SELECT username, password, email, last_login
                     FROM accounts_user u
                         LEFT OUTER JOIN accounts_email e ON (e.user_id = u.id)
                     WHERE u.id = (
@@ -1603,7 +1603,7 @@ class Store:
             such user.
         '''
         cursor = self.get_cursor()
-        sql = """SELECT username, password, email, key_id, last_login
+        sql = """SELECT username, password, email, last_login
                     FROM accounts_user u
                         LEFT OUTER JOIN accounts_email e ON (e.user_id = u.id)
                     WHERE u.username = (
@@ -1622,7 +1622,7 @@ class Store:
             such user.
         '''
         cursor = self.get_cursor()
-        sql = """SELECT username, password, email, key_id, last_login
+        sql = """SELECT username, password, email, last_login
                     FROM accounts_user u
                         LEFT OUTER JOIN accounts_email e ON (e.user_id = u.id)
                     WHERE u.username = (

--- a/store.py
+++ b/store.py
@@ -1430,7 +1430,7 @@ class Store:
         safe_execute(cursor, sql, (name,))
         return int(cursor.fetchone()[0])
 
-    def store_user(self, name, password, email, gpg_keyid="", otk=True):
+    def store_user(self, name, password, email, otk=True):
         ''' Store info about the user to the database.
 
             The "password" argument is passed in cleartext and sha-ed
@@ -1487,23 +1487,6 @@ class Store:
                 """
                 safe_execute(cursor, sql, (user_id, email))
 
-            if gpg_keyid is not None:
-                # We've been given a new GPG Key ID for this user
-
-                # Delete existing GPG Key IDs
-                safe_execute(cursor,
-                    "DELETE FROM accounts_gpgkey WHERE user_id = %s",
-                    (user_id,)
-                )
-
-                if gpg_keyid:
-                    # Create a new GPG Key for the user
-                    safe_execute(cursor,
-                        """INSERT INTO accounts_gpgkey (user_id, key_id, verified)
-                            VALUES (%s, %s, FALSE)
-                        """,
-                        (user_id, gpg_keyid)
-                    )
         else:
             # New User so we will create new entries
 
@@ -1548,15 +1531,6 @@ class Store:
                     (user_id, email)
                 )
 
-            if gpg_keyid:
-                # We have a gpg key id for this user
-                safe_execute(cursor,
-                    """INSERT INTO accounts_gpgkey (user_id, key_id, verified)
-                        VALUES (%s, %s, FALSE)
-                    """,
-                    (user_id, gpg_keyid)
-                )
-
             if otk:
                 # We want an OTK so we'll generate one
                 otkv = generate_random(32)
@@ -1585,7 +1559,7 @@ class Store:
         sql = "UPDATE accounts_user SET is_active = TRUE WHERE username = %s"
         safe_execute(cursor, sql, (username,))
 
-    _User = FastResultRow('name password email gpg_keyid last_login!')
+    _User = FastResultRow('name password email last_login!')
     def get_user(self, name):
         ''' Retrieve info about the user from the database.
 
@@ -1596,7 +1570,6 @@ class Store:
         sql = """SELECT username, password, email, key_id, last_login
                     FROM accounts_user u
                         LEFT OUTER JOIN accounts_email e ON (e.user_id = u.id)
-                        LEFT OUTER JOIN accounts_gpgkey g ON (g.user_id = u.id)
                     WHERE username = %s
         """
         safe_execute(cursor, sql, (name,))
@@ -1613,7 +1586,6 @@ class Store:
         sql = """SELECT username, password, email, key_id, last_login
                     FROM accounts_user u
                         LEFT OUTER JOIN accounts_email e ON (e.user_id = u.id)
-                        LEFT OUTER JOIN accounts_gpgkey g ON (g.user_id = u.id)
                     WHERE u.id = (
                                     SELECT user_id
                                     FROM accounts_email
@@ -1634,7 +1606,6 @@ class Store:
         sql = """SELECT username, password, email, key_id, last_login
                     FROM accounts_user u
                         LEFT OUTER JOIN accounts_email e ON (e.user_id = u.id)
-                        LEFT OUTER JOIN accounts_gpgkey g ON (g.user_id = u.id)
                     WHERE u.username = (
                                     SELECT name FROM openids WHERE id = %s
                                 )
@@ -1654,7 +1625,6 @@ class Store:
         sql = """SELECT username, password, email, key_id, last_login
                     FROM accounts_user u
                         LEFT OUTER JOIN accounts_email e ON (e.user_id = u.id)
-                        LEFT OUTER JOIN accounts_gpgkey g ON (g.user_id = u.id)
                     WHERE u.username = (
                                     SELECT name FROM openids WHERE sub = %s
                                 )

--- a/templates/register.pt
+++ b/templates/register.pt
@@ -47,14 +47,6 @@
 	  <td><input name="email" tal:attributes="value data/email" /></td>
 	</tr>
 	<tr>
-	  <th>PGP Key ID (optional):</th>
-	  <td><input name="gpg_keyid" tal:attributes="value data/gpg_keyid" />
-          (This identifies a <a
-          href="http://www.gnupg.org/documentation/howtos.html">PGP or GPG
-          key</a>)
-          </td>
-	</tr>
-	<tr>
 	  <th></th>
 	  <td><input type="submit" tal:attributes="value data/action" /></td>
 	</tr>

--- a/templates/security.pt
+++ b/templates/security.pt
@@ -25,7 +25,7 @@ servers like pgp.mit.edu.</p>
 
 <p>You may sign your uploads with GPG using the "--sign" argument to "python setup.py upload".</p>
 
-<p>The MD5 hash provided with files on PyPI exists <b>only</b> to provide some download corruption protection. It is <b>not</b> intended to provide any sort of security regarding tampering. Please use GPG signing for that.</p>
+<p>The file checksums provided with files on PyPI exists <b>only</b> to provide some download corruption protection. It is <b>not</b> intended to provide any sort of security regarding tampering. Please use GPG signing and verification via your <a href="https://en.wikipedia.org/wiki/Web_of_trust">Web of Trust</a> for that.</p>
 
  </metal:fill>
 </html>


### PR DESCRIPTION
removes presentation, registration of, and all other GPG/PGP Key ID handling from PyPI.

this feature will not return as if you are working to verify GPG fingerprints, you should consult the public key server infrastructure or leverage your own web of trust to obtain and verify ownership of a given Key.

closes #76