### PR TITLE
Fix verb vs. noun typos for 'login'

### DIFF
--- a/templates/standard_template.pt
+++ b/templates/standard_template.pt
@@ -140,15 +140,15 @@
 
                   <ul>
 		    <li tal:condition="app/username"><a tal:attributes="href python:app.link_action('clear_auth')">Clear Basic Auth</a></li>
-                    <li><a tal:attributes="href python: app.link_action('login_form')">Login</a></li>
+                    <li><a tal:attributes="href python: app.link_action('login_form')">Log in</a></li>
                     <li><a tal:attributes="href python: app.link_action('register_form')">Register</a></li>
                     <li><a tal:attributes="href python: app.link_action('forgotten_password_form')">Lost Login?</a></li>
-		    <li><a href="/openid_login">Login with OpenID</a>
+		    <li><a href="/openid_login">Log in with OpenID</a>
                       <tal:block tal:repeat="prov data/providers">
                         <a style="border: none;" tal:attributes="href prov/login"><img width="16" height="16" tal:attributes="src prov/favicon; title prov/title; alt prov/title"/></a>
                       </tal:block>
                     </li>
-                    <li><a href="/google_login">Login with Google<img width="16" height="16" src="https://www.google.com/favicon.ico" title="Google Login" alt="Google Login"></img></a></li>
+                    <li><a href="/google_login">Log in with Google<img width="16" height="16" src="https://www.google.com/favicon.ico" title="Google Login" alt="Google Login"></img></a></li>
                   </ul>
 
 		</tal:if-not-user>


### PR DESCRIPTION
Simple verb vs. noun usages of "log in" and "login," respectively.